### PR TITLE
Report Web3Dart PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Credentials random = EthPrivateKey.createRandom(rng);
 
 // In either way, the library can derive the public key and the address
 // from a private key:
-var address = await credentials.extractAddress();
+var address = credentials.address;
 print(address.hex);
 ```
 
@@ -105,7 +105,7 @@ var httpClient = Client();
 var ethClient = Web3Client(apiUrl, httpClient);
 
 var credentials = EthPrivateKey.fromHex("0x...");
-var address = await credentials.extractAddress();
+var address = await credentials.address;
 
 // You can now call rpc methods. This one will query the amount of Ether you own
 EtherAmount balance = ethClient.getBalance(address);

--- a/README.md
+++ b/README.md
@@ -104,10 +104,11 @@ var apiUrl = "http://localhost:7545"; //Replace with your API
 var httpClient = Client();
 var ethClient = Web3Client(apiUrl, httpClient);
 
-var credentials = ethClient.credentialsFromPrivateKey("0x...");
+var credentials = EthPrivateKey.fromHex("0x...");
+var address = await credentials.extractAddress();
 
 // You can now call rpc methods. This one will query the amount of Ether you own
-EtherAmount balance = ethClient.getBalance(credentials.address);
+EtherAmount balance = ethClient.getBalance(address);
 print(balance.getValueInUnit(EtherUnit.ether));
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ await client.sendTransaction(
     to: EthereumAddress.fromHex('0xC91...3706'),
     gasPrice: EtherAmount.inWei(BigInt.one),
     maxGas: 100000,
-    value: EtherAmount.fromUnitAndValue(EtherUnit.ether, 1),
+    value: EtherAmount.fromInt(EtherUnit.ether, 1),
   ),
 );
 ```

--- a/example/main.dart
+++ b/example/main.dart
@@ -21,7 +21,7 @@ Future<void> main() async {
       to: EthereumAddress.fromHex('0xC914Bb2ba888e3367bcecEb5C2d99DF7C7423706'),
       gasPrice: EtherAmount.inWei(BigInt.one),
       maxGas: 100000,
-      value: EtherAmount.fromUnitAndValue(EtherUnit.ether, 1),
+      value: EtherAmount.fromInt(EtherUnit.ether, 1),
     ),
   );
 

--- a/lib/json_rpc.dart
+++ b/lib/json_rpc.dart
@@ -50,7 +50,6 @@ class JsonRPC extends RpcService {
     );
 
     final data = json.decode(response.body) as Map<String, dynamic>;
-    final id = data['id'] as int;
 
     if (data.containsKey('error')) {
       final error = data['error'];
@@ -62,6 +61,7 @@ class JsonRPC extends RpcService {
       throw RPCError(code, message, errorData);
     }
 
+    final id = data['id'] as int;
     final result = data['result'];
     return RPCResponse(id, result);
   }

--- a/lib/src/contracts/abi/abi.dart
+++ b/lib/src/contracts/abi/abi.dart
@@ -316,7 +316,7 @@ class ContractEvent {
   /// Indexed parameters which would take more than 32 bytes to encode are not
   /// included in the result. Apart from that, the order of the data returned
   /// is identical to the order of the [components].
-  List<dynamic> decodeResults(List<String> topics, String data) {
+  List<dynamic> decodeResults(List<String?> topics, String data) {
     final topicOffset = anonymous ? 0 : 1;
 
     // non-indexed parameters are decoded like a tuple
@@ -341,12 +341,14 @@ class ContractEvent {
         // dynamic type, are not included in [topics]. A hash of the data will
         // be included instead. We can't decode these, so they will be skipped.
         final length = component.parameter.type.encodingLength;
-        if (length.isDynamic || length.length! > 32) {
+        if (length.isDynamic ||
+            length.length! > 32 ||
+            topics[topicIndex] == null) {
           topicIndex++;
           continue;
         }
 
-        final topicBuffer = hexToBytes(topics[topicIndex]).buffer;
+        final topicBuffer = hexToBytes(topics[topicIndex]!).buffer;
         result.add(component.parameter.type.decode(topicBuffer, 0).data);
 
         topicIndex++;

--- a/lib/src/core/block_information.dart
+++ b/lib/src/core/block_information.dart
@@ -89,7 +89,7 @@ class BlockInformation {
     final String? _nonce =
         json.containsKey('nonce') ? json['nonce'] as String : null;
     final EtherAmount? _baseFeePerGas = json.containsKey('baseFeePerGas')
-        ? EtherAmount.fromUnitAndValue(
+        ? EtherAmount.fromBigInt(
             EtherUnit.wei, hexToInt(json['baseFeePerGas'] as String))
         : null;
     final int? _number = json.containsKey('number')
@@ -193,7 +193,7 @@ class BlockInformation {
 // EtherAmount? _parseBaseFeePerGas(Map<String, dynamic> map) {
 //   if (!map.containsKey('baseFeePerGas')) return null;
 
-//   return EtherAmount.fromUnitAndValue(
+//   return EtherAmount.fromBigInt(
 //     EtherUnit.wei,
 //     hexToInt(map['baseFeePerGas'] as String),
 //   );

--- a/lib/src/core/client.dart
+++ b/lib/src/core/client.dart
@@ -180,7 +180,7 @@ class Web3Client {
   Future<EtherAmount> getGasPrice() async {
     final data = await _makeRPCCall<String>('eth_gasPrice');
 
-    return EtherAmount.fromUnitAndValue(EtherUnit.wei, hexToInt(data));
+    return EtherAmount.fromBigInt(EtherUnit.wei, hexToInt(data));
   }
 
   /// Returns the number of the most recent block on the chain.
@@ -216,7 +216,7 @@ class Web3Client {
 
     return _makeRPCCall<String>('eth_getBalance', [address.hex, blockParam])
         .then((data) {
-      return EtherAmount.fromUnitAndValue(EtherUnit.wei, hexToInt(data));
+      return EtherAmount.fromBigInt(EtherUnit.wei, hexToInt(data));
     });
   }
 
@@ -424,8 +424,9 @@ class Web3Client {
       client: this,
     );
 
-    return _signTransaction(signingInput.transaction, signingInput.credentials,
-        signingInput.chainId);
+    return signTransactionRaw(
+        signingInput.transaction, signingInput.credentials,
+        chainId: signingInput.chainId);
   }
 
   /// Calls a [function] defined in the smart [contract] and returns it's

--- a/lib/src/core/eip1559_information.dart
+++ b/lib/src/core/eip1559_information.dart
@@ -1,4 +1,4 @@
-import 'package:webthree/src/core/amount.dart';
+part of webthree;
 
 class EIP1559Information {
   EIP1559Information({

--- a/lib/src/core/ether_amount.dart
+++ b/lib/src/core/ether_amount.dart
@@ -1,49 +1,17 @@
-enum EtherUnit {
-  ///Wei, the smallest and atomic amount of Ether
-  wei,
-
-  ///kwei, 1000 wei
-  kwei,
-
-  ///Mwei, one million wei
-  mwei,
-
-  ///Gwei, one billion wei. Typically a reasonable unit to measure gas prices.
-  gwei,
-
-  ///szabo, 10^12 wei or 1 μEther
-  szabo,
-
-  ///finney, 10^15 wei or 1 mEther
-  finney,
-
-  ether
-}
+part of webthree;
 
 /// Utility class to easily convert amounts of Ether into different units of
 /// quantities.
 class EtherAmount {
-  static final Map<EtherUnit, BigInt> _factors = {
-    EtherUnit.wei: BigInt.one,
-    EtherUnit.kwei: BigInt.from(10).pow(3),
-    EtherUnit.mwei: BigInt.from(10).pow(6),
-    EtherUnit.gwei: BigInt.from(10).pow(9),
-    EtherUnit.szabo: BigInt.from(10).pow(12),
-    EtherUnit.finney: BigInt.from(10).pow(15),
-    EtherUnit.ether: BigInt.from(10).pow(18)
-  };
-
-  final BigInt _value;
-
-  BigInt get getInWei => _value;
-  BigInt get getInEther => getValueInUnitBI(EtherUnit.ether);
-
   const EtherAmount.inWei(this._value);
 
   EtherAmount.zero() : this.inWei(BigInt.zero);
 
   /// Constructs an amount of Ether by a unit and its amount. [amount] can
-  /// either be a base10 string, an int, or a BigInt.
+  /// either be a base10 string, an int or a BigInt.
+  @Deprecated(
+    'Please use fromInt, fromBigInt or fromBase10String.',
+  )
   factory EtherAmount.fromUnitAndValue(EtherUnit unit, dynamic amount) {
     BigInt parsedAmount;
 
@@ -60,12 +28,48 @@ class EtherAmount {
     return EtherAmount.inWei(parsedAmount * _factors[unit]!);
   }
 
+  /// Constructs an amount of Ether by a unit and its amount.
+  factory EtherAmount.fromInt(EtherUnit unit, int amount) {
+    final wei = _factors[unit]! * BigInt.from(amount);
+
+    return EtherAmount.inWei(wei);
+  }
+
+  /// Constructs an amount of Ether by a unit and its amount.
+  factory EtherAmount.fromBigInt(EtherUnit unit, BigInt amount) {
+    final wei = _factors[unit]! * amount;
+
+    return EtherAmount.inWei(wei);
+  }
+
+  /// Constructs an amount of Ether by a unit and its amount.
+  factory EtherAmount.fromBase10String(EtherUnit unit, String amount) {
+    final wei = _factors[unit]! * BigInt.parse(amount);
+
+    return EtherAmount.inWei(wei);
+  }
+
   /// Gets the value of this amount in the specified unit as a whole number.
   /// **WARNING**: For all units except for [EtherUnit.wei], this method will
   /// discard the remainder occurring in the division, making it unsuitable for
   /// calculations or storage. You should store and process amounts of ether by
   /// using a BigInt storing the amount in wei.
   BigInt getValueInUnitBI(EtherUnit unit) => _value ~/ _factors[unit]!;
+
+  static final Map<EtherUnit, BigInt> _factors = {
+    EtherUnit.wei: BigInt.one,
+    EtherUnit.kwei: BigInt.from(10).pow(3),
+    EtherUnit.mwei: BigInt.from(10).pow(6),
+    EtherUnit.gwei: BigInt.from(10).pow(9),
+    EtherUnit.szabo: BigInt.from(10).pow(12),
+    EtherUnit.finney: BigInt.from(10).pow(15),
+    EtherUnit.ether: BigInt.from(10).pow(18),
+  };
+
+  final BigInt _value;
+
+  BigInt get getInWei => _value;
+  BigInt get getInEther => getValueInUnitBI(EtherUnit.ether);
 
   /// Gets the value of this amount in the specified unit. **WARNING**: Due to
   /// rounding errors, the return value of this function is not reliable,

--- a/lib/src/core/ether_unit.dart
+++ b/lib/src/core/ether_unit.dart
@@ -1,0 +1,24 @@
+part of webthree;
+
+enum EtherUnit {
+  /// Wei, the smallest and atomic amount of Ether
+  wei,
+
+  /// kwei, 1000 wei
+  kwei,
+
+  /// Mwei, one million wei
+  mwei,
+
+  /// Gwei, one billion wei. Typically a reasonable unit to measure gas prices.
+  gwei,
+
+  /// szabo, 10^12 wei or 1 μEther
+  szabo,
+
+  /// finney, 10^15 wei or 1 mEther
+  finney,
+
+  /// 1 Ether
+  ether,
+}

--- a/lib/src/core/filters.dart
+++ b/lib/src/core/filters.dart
@@ -116,7 +116,7 @@ class FilterOptions {
   /// All further topics are the encoded values of the indexed parameters of the
   /// event. See https://solidity.readthedocs.io/en/develop/contracts.html#events
   /// for a detailed description.
-  final List<List<String>>? topics;
+  final List<List<String?>>? topics;
 }
 
 /// A log event emitted in a transaction.
@@ -150,7 +150,7 @@ class FilterEvent {
             : null,
         address = EthereumAddress.fromHex(log['address'] as String),
         data = log['data'] as String?,
-        topics = (log['topics'] as List?)?.cast<String>();
+        topics = (log['topics'] as List?)?.cast<String?>();
 
   Map<String, dynamic> toMap() {
     return {
@@ -205,7 +205,7 @@ class FilterEvent {
   /// For solidity events, the first topic is a hash of the event signature
   /// (except for anonymous events). All further topics are the encoded
   /// values of indexed parameters.
-  final List<String>? topics;
+  final List<String?>? topics;
 
   @override
   String toString() {

--- a/lib/src/core/transaction.dart
+++ b/lib/src/core/transaction.dart
@@ -92,5 +92,5 @@ class Transaction {
     );
   }
 
-  bool get isEIP1559 => maxFeePerGas != null && maxPriorityFeePerGas != null;
+  bool get isEIP1559 => maxFeePerGas != null || maxPriorityFeePerGas != null;
 }

--- a/lib/src/core/transaction_signer.dart
+++ b/lib/src/core/transaction_signer.dart
@@ -36,6 +36,17 @@ Future<_SigningInput> _fillMissingData({
     gasPrice = await client!.getGasPrice();
   }
 
+  var maxFeePerGas = transaction.maxFeePerGas;
+  var maxPriorityFeePerGas = transaction.maxPriorityFeePerGas;
+
+  if (transaction.isEIP1559) {
+    maxPriorityFeePerGas ??= await _getMaxPriorityFeePerGas();
+    maxFeePerGas ??= await _getMaxFeePerGas(
+      client!,
+      maxPriorityFeePerGas.getInWei,
+    );
+  }
+
   final nonce = transaction.nonce ??
       await client!
           .getTransactionCount(sender, atBlock: const BlockNum.pending());
@@ -48,8 +59,8 @@ Future<_SigningInput> _fillMissingData({
             data: transaction.data,
             value: transaction.value,
             gasPrice: gasPrice,
-            maxPriorityFeePerGas: transaction.maxPriorityFeePerGas,
-            maxFeePerGas: transaction.maxFeePerGas,
+            maxPriorityFeePerGas: maxPriorityFeePerGas,
+            maxFeePerGas: maxFeePerGas,
           )
           .then((bigInt) => bigInt.toInt());
 
@@ -61,6 +72,8 @@ Future<_SigningInput> _fillMissingData({
     data: transaction.data ?? Uint8List(0),
     gasPrice: gasPrice,
     nonce: nonce,
+    maxPriorityFeePerGas: maxPriorityFeePerGas,
+    maxFeePerGas: maxFeePerGas,
   );
 
   int resolvedChainId;
@@ -165,4 +178,28 @@ List<dynamic> _encodeToRlp(Transaction transaction, MsgSignature? signature) {
   }
 
   return list;
+}
+
+Future<EtherAmount> _getMaxPriorityFeePerGas() {
+  // We may want to compute this more accurately in the future,
+  // using the formula "check if the base fee is correct".
+  // See: https://eips.ethereum.org/EIPS/eip-1559
+  return Future.value(EtherAmount.inWei(BigInt.from(1000000000)));
+}
+
+// Max Fee = (2 * Base Fee) + Max Priority Fee
+Future<EtherAmount> _getMaxFeePerGas(
+  Web3Client client,
+  BigInt maxPriorityFeePerGas,
+) async {
+  final blockInformation = await client.getBlockInformation();
+  final baseFeePerGas = blockInformation.baseFeePerGas;
+
+  if (baseFeePerGas == null) {
+    return EtherAmount.zero();
+  }
+
+  return EtherAmount.inWei(
+    baseFeePerGas.getInWei * BigInt.from(2) + maxPriorityFeePerGas,
+  );
 }

--- a/lib/src/core/transaction_signer.dart
+++ b/lib/src/core/transaction_signer.dart
@@ -83,8 +83,8 @@ Uint8List prependTransactionType(int type, Uint8List transaction) {
     ..setAll(1, transaction);
 }
 
-Future<Uint8List> _signTransaction(
-    Transaction transaction, Credentials c, int? chainId) async {
+Future<Uint8List> signTransactionRaw(Transaction transaction, Credentials c,
+    {int? chainId = 1}) async {
   if (transaction.isEIP1559 && chainId != null) {
     final encodedTx = LengthTrackingByteSink();
     encodedTx.addByte(0x02);

--- a/lib/src/credentials/did.dart
+++ b/lib/src/credentials/did.dart
@@ -1,0 +1,38 @@
+import '../../credentials.dart';
+import '../../crypto.dart';
+
+class EthrDID {
+  const EthrDID(this.did);
+
+  factory EthrDID.fromPublicKeyEncoded({
+    required EthPrivateKey credentials,
+    required String chainNameOrId,
+  }) {
+    final did = 'did:ethr:$chainNameOrId:${bytesToHex(
+      credentials.publicKey.getEncoded(),
+      include0x: true,
+    )}';
+    return EthrDID(did);
+  }
+
+  factory EthrDID.fromEthereumAddress({
+    required EthereumAddress address,
+    required String chainNameOrId,
+  }) {
+    final did = 'did:ethr:$chainNameOrId:${address.hexEip55}';
+    return EthrDID(did);
+  }
+
+  /// `identifier` is Ethereum address, public key or a full did:ethr representing Identity
+  ///
+  /// https://github.com/uport-project/ethr-did#configuration
+  factory EthrDID.fromIdentifier({
+    required String identifier,
+    required String chainNameOrId,
+  }) {
+    final did = 'did:ethr:$chainNameOrId:$identifier';
+    return EthrDID(did);
+  }
+
+  final String did;
+}

--- a/lib/webthree.dart
+++ b/lib/webthree.dart
@@ -15,21 +15,22 @@ import 'contracts.dart';
 import 'credentials.dart';
 import 'crypto.dart';
 import 'json_rpc.dart';
-import 'src/core/amount.dart';
 import 'src/core/block_information.dart';
 import 'src/core/block_number.dart';
-import 'src/core/eip1559_information.dart';
 import 'src/core/sync_information.dart';
+
 import 'src/utils/rlp.dart' as rlp;
 import 'src/utils/typed_data.dart';
 
 export 'contracts.dart';
 export 'credentials.dart';
-export 'src/core/amount.dart';
 export 'src/core/block_information.dart';
 export 'src/core/block_number.dart';
-export 'src/core/eip1559_information.dart';
 export 'src/core/sync_information.dart';
+
+part 'src/core/ether_unit.dart';
+part 'src/core/ether_amount.dart';
+part 'src/core/eip1559_information.dart';
 
 part 'src/core/client.dart';
 part 'src/core/filters.dart';

--- a/test/core/sign_transaction_test.dart
+++ b/test/core/sign_transaction_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:http/http.dart';
 import 'package:test/test.dart';
@@ -124,9 +125,9 @@ void main() {
           nonce: tx['nonce'] as int,
           maxGas: tx['gasLimit'] as int,
           value: EtherAmount.inWei(BigInt.from(tx['value'] as int)),
-          maxFeePerGas: EtherAmount.fromUnitAndValue(
+          maxFeePerGas: EtherAmount.fromBigInt(
               EtherUnit.wei, BigInt.from(tx['maxFeePerGas'] as int)),
-          maxPriorityFeePerGas: EtherAmount.fromUnitAndValue(
+          maxPriorityFeePerGas: EtherAmount.fromBigInt(
               EtherUnit.wei, BigInt.from(tx['maxPriorityFeePerGas'] as int)));
 
       final client = Web3Client('', Client());
@@ -137,6 +138,44 @@ void main() {
           bytesToHex(uint8ListFromList(
               rlp.encode(prependTransactionType(0x02, signature)))),
           strip0x(tx['signedTransactionRLP'] as String));
+    });
+  });
+
+  test('sign eip 1559 transaction without client', () async {
+    final data = jsonDecode(rawJson) as List<dynamic>;
+
+    await Future.forEach(data, (element) async {
+      final tx = element as Map<String, dynamic>;
+      final credentials =
+          EthPrivateKey.fromHex(strip0x(tx['privateKey'] as String));
+      final transaction = Transaction(
+        from: credentials.address,
+        to: EthereumAddress.fromHex(tx['to'] as String),
+        nonce: tx['nonce'] as int,
+        maxGas: tx['gasLimit'] as int,
+        value: EtherAmount.inWei(BigInt.from(tx['value'] as int)),
+        maxFeePerGas: EtherAmount.fromBigInt(
+          EtherUnit.wei,
+          BigInt.from(tx['maxFeePerGas'] as int),
+        ),
+        maxPriorityFeePerGas: EtherAmount.fromBigInt(
+          EtherUnit.wei,
+          BigInt.from(tx['maxPriorityFeePerGas'] as int),
+        ),
+        data: tx['data'] ?? Uint8List(0),
+      );
+
+      final signature =
+          await signTransactionRaw(transaction, credentials, chainId: 4);
+
+      expect(
+        bytesToHex(
+          uint8ListFromList(
+            rlp.encode(prependTransactionType(0x02, signature)),
+          ),
+        ),
+        strip0x(tx['signedTransactionRLP'] as String),
+      );
     });
   });
 

--- a/test/credentials/ethr_did_test.dart
+++ b/test/credentials/ethr_did_test.dart
@@ -1,0 +1,48 @@
+import 'package:test/test.dart';
+import 'package:webthree/credentials.dart';
+import 'package:webthree/crypto.dart';
+import 'package:webthree/src/credentials/did.dart';
+
+void main() {
+  group('Generate ethr DID', () {
+    test('from Ethereum Address', () {
+      var address =
+          EthereumAddress.fromHex('0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb');
+      var ethrDID =
+          EthrDID.fromEthereumAddress(address: address, chainNameOrId: '0x1');
+      expect(
+        ethrDID.did,
+        'did:ethr:0x1:0xD1220A0cf47c7B9Be7A2E6BA89F429762e7b9aDb',
+      );
+    });
+
+    test('from PublicKey Encoded', () {
+      final key = EthPrivateKey(
+        hexToBytes(
+          'a392604efc2fad9c0b3da43b5f698a2e3f270f170d859912be0d54742275c5f6',
+        ),
+      );
+      var ethrDID =
+          EthrDID.fromPublicKeyEncoded(credentials: key, chainNameOrId: '0x1');
+      expect(
+        bytesToHex(key.publicKey.getEncoded(), include0x: true),
+        '0x02506bc1dc099358e5137292f4efdd57e400f29ba5132aa5d12b18dac1c1f6aaba',
+      );
+      expect(
+        ethrDID.did,
+        'did:ethr:0x1:0x02506bc1dc099358e5137292f4efdd57e400f29ba5132aa5d12b18dac1c1f6aaba',
+      );
+    });
+
+    test('from Identifier', () {
+      var ethrDID = EthrDID.fromIdentifier(
+        identifier: 'web3dart',
+        chainNameOrId: 'goerli',
+      );
+      expect(
+        ethrDID.did,
+        'did:ethr:goerli:web3dart',
+      );
+    });
+  });
+}


### PR DESCRIPTION
Report of Web3Dart's PR
- PR 115 : Report Fix for errors in generated dart bindings
- PR 114: Feature Addition: EthrDID Constructors
- PR 108: Implemented calculation of max fee per gas
- PR 106: add nullable topics in filters 
- PR 86: Eip1559
- PR 79: Report Replace depreciated field access in ReadMe snippets 
- PR 73: Report JSON-RPC: fix type-error to get useful RPCErrors
- PR 19: Update readme to remove deprecated method

I let you check Unit tests because i have these issues
1) ```Tests require the INFURA_ID environment variable```

2) i don't know how to fix this: 
```0:06 +90 ~3 -1: /Users/SSe/SSe/app/SANDBOX/webthree/test/builder/builder_goldens_test.dart: builder test #0 [E]             
  Expected: '// Generated code, do not modify. Run `build_runner build` to re-generate!\n'
              '// @dart=2.12\n'
              'import \'package:webthree/webthree.dart\' as _i1;\n'
              '\n'
              'final _contractAbi = _i1.ContractAbi.fromJson(\n'
              '    \'[{"inputs":[{"internalType":"uint240","name":"first","type":"uint240"},{"internalType":"uint248","name":"second","type":"uint248"}],"name":"retrieve3","outputs":[{"internalType":"string","name":"","type":"string"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"pure","type":"function"}]\',\n'
              '    \'Contract\');\n'
              '\n'
              'class Contract extends _i1.GeneratedContract {\n'
              '  Contract(\n'
              '      {required _i1.EthereumAddress address,\n'
              '      required _i1.Web3Client client,\n'
              '      int? chainId})\n'
              '      : super(_i1.DeployedContract(_contractAbi, address), client, chainId);\n'
              '\n'
              '  /// The optional [atBlock] parameter can be used to view historical data. When\n'
              '  /// set, the function will be evaluated in the specified block. By default, the\n'
              '  /// latest on-chain block will be used.\n'
              '  Future<Retrieve3> retrieve3(BigInt first, BigInt second,\n'
              '      {_i1.BlockNum? atBlock}) async {\n'
              '    final function = self.abi.functions[0];\n'
              '    assert(checkSignature(function, \'2783b284\'));\n'
              '    final params = [first, second];\n'
              '    final response = await read(function, params, atBlock);\n'
              '    return Retrieve3(response);\n'
              '  }\n'
              '}\n'
              '\n'
              'class Retrieve3 {\n'
              '  Retrieve3(List<dynamic> response)\n'
              '      : var1 = (response[0] as String),\n'
              '        var2 = (response[1] as BigInt),\n'
              '        var3 = (response[2] as bool);\n'
              '\n'
              '  final String var1;\n'
              '\n'
              '  final BigInt var2;\n'
              '\n'
              '  final bool var3;\n'
              '}\n'
              ''
    Actual: '// Generated code, do not modify. Run `build_runner build` to re-generate!\n'
              '// @dart=2.12\n'
              '// ignore_for_file: no_leading_underscores_for_library_prefixes\n'
              'import \'package:webthree/webthree.dart\' as _i1;\n'
              '\n'
              'final _contractAbi = _i1.ContractAbi.fromJson(\n'
              '  \'[{"inputs":[{"internalType":"uint240","name":"first","type":"uint240"},{"internalType":"uint248","name":"second","type":"uint248"}],"name":"retrieve3","outputs":[{"internalType":"string","name":"","type":"string"},{"internalType":"uint256","name":"","type":"uint256"},{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"pure","type":"function"}]\',\n'
              '  \'Contract\',\n'
              ');\n'
              '\n'
              'class Contract extends _i1.GeneratedContract {\n'
              '  Contract({\n'
              '    required _i1.EthereumAddress address,\n'
              '    required _i1.Web3Client client,\n'
              '    int? chainId,\n'
              '  }) : super(\n'
              '          _i1.DeployedContract(\n'
              '            _contractAbi,\n'
              '            address,\n'
              '          ),\n'
              '          client,\n'
              '          chainId,\n'
              '        );\n'
              '\n'
              '  /// The optional [atBlock] parameter can be used to view historical data. When\n'
              '  /// set, the function will be evaluated in the specified block. By default, the\n'
              '  /// latest on-chain block will be used.\n'
              '  Future<Retrieve3> retrieve3(\n'
              '    BigInt first,\n'
              '    BigInt second, {\n'
              '    _i1.BlockNum? atBlock,\n'
              '    _i1.EthereumAddress? sender,\n'
              '  }) async {\n'
              '    final function = self.abi.functions[0];\n'
              '    assert(checkSignature(function, \'2783b284\'));\n'
              '    final params = [\n'
              '      first,\n'
              '      second,\n'
              '    ];\n'
              '    final response = await read(\n'
              '      sender,\n'
              '      function,\n'
              '      params,\n'
              '      atBlock,\n'
              '    );\n'
              '    return Retrieve3(response);\n'
              '  }\n'
              '}\n'
              '\n'
              'class Retrieve3 {\n'
              '  Retrieve3(List<dynamic> response)\n'
              '      : var1 = (response[0] as String),\n'
              '        var2 = (response[1] as BigInt),\n'
              '        var3 = (response[2] as bool);\n'
              '\n'
              '  final String var1;\n'
              '\n'
              '  final BigInt var2;\n'
              '\n'
              '  final bool var3;\n'
              '}\n'
              ''
     Which: is different.
            Expected: ... art=2.12\nimport 'pa ...
              Actual: ... art=2.12\n// ignore_ ...
                                    ^
             Differ at offset 91
  Unexpected content for a|lib/contract.g.dart in result.outputs.
  
  package:matcher                                 expect
  package:build_test/src/test_builder.dart 70:7   checkOutputs.<fn>
  dart:collection                                 _LinkedHashMapMixin.forEach
  package:build_test/src/test_builder.dart 47:13  checkOutputs
  package:build_test/src/test_builder.dart 193:3  testBuilder```