### PR TITLE
Handle rawRequest errors

### DIFF
--- a/lib/src/browser/dart_wrappers.dart
+++ b/lib/src/browser/dart_wrappers.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:js/js_util.dart';
+import 'package:webthree/src/core/exception.dart';
 
 import '../../credentials.dart';
 import '../../json_rpc.dart';
@@ -43,7 +44,9 @@ extension DartEthereum on Ethereum {
     final args = params == null
         ? RequestArguments(method: method)
         : RequestArguments(method: method, params: params);
-    return promiseToFuture(request(args));
+    return promiseToFuture(request(args)).onError((error, stackTrace) {
+      ExceptionUtils.analyzeException(error!);
+    });
   }
 
   /// Asks the user to select an account and give your application access to it.

--- a/lib/src/browser/dart_wrappers.dart
+++ b/lib/src/browser/dart_wrappers.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 
 import 'package:js/js_util.dart';
-import 'package:webthree/src/core/exception.dart';
+import 'package:webthree/src/core/exception_utils_js.dart'
+    if (dart.library.io) 'package:webthree/src/core/exception_utils_js.dart'
+    if (dart.library.js) 'package:webthree/src/core/exception_utils_js.dart';
 
 import '../../credentials.dart';
 import '../../json_rpc.dart';

--- a/lib/src/core/exception.dart
+++ b/lib/src/core/exception.dart
@@ -1,8 +1,3 @@
-import 'dart:convert';
-
-import 'package:webthree/json_rpc.dart';
-import 'package:webthree/src/browser/js_util_stub.dart';
-
 class EthereumUserRejected implements Exception {
   @override
   String toString() => 'EthereumUserRejected: User rejected the request';
@@ -28,56 +23,4 @@ class EthersException implements Exception {
 
   @override
   String toString() => 'EthersException: $code $reason';
-}
-
-class ExceptionUtils {
-  ExceptionUtils();
-
-  /// Analyze Exception to throw a typed exception
-  static void analyzeException(Object e) {
-    // Case of Trust Wallet for example...
-    if (e.runtimeType.toString() == 'NativeError') {
-      if (e.toString().toLowerCase().contains('user rejected the request')) {
-        throw EthereumUserRejected();
-      } else {
-        throw UnimplementedError(e.toString());
-      }
-    } else {
-      // Case of Metamask...
-      final err = json.decode(json.encode(dartify(e))) as Map<String, dynamic>;
-      switch (err['code']) {
-        case 4001:
-          throw EthereumUserRejected();
-        case -32603:
-          String rpcErrorData = err['message'].toString().replaceFirst(
-              "[ethjs-query] while formatting outputs from RPC '{\"value\":",
-              '');
-          if (rpcErrorData.length - 2 > 0) {
-            rpcErrorData = rpcErrorData.substring(0, rpcErrorData.length - 2);
-          }
-          final rpcErrorJson = json.decode(rpcErrorData);
-          throw RPCError(
-            rpcErrorJson['data']['code'] ?? '',
-            rpcErrorJson['data']['message'] ?? '',
-            rpcErrorJson['data']['data'] ?? '',
-          );
-        default:
-          if (err['message'] != null) {
-            throw EthereumException(
-              err['code'],
-              err['message'],
-              err['data'],
-            );
-          } else if (err['reason'] != null) {
-            throw EthersException(
-              err['code'],
-              err['reason'],
-              err,
-            );
-          } else {
-            throw UnimplementedError(e.toString());
-          }
-      }
-    }
-  }
 }

--- a/lib/src/core/exception.dart
+++ b/lib/src/core/exception.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
+import 'package:js/js_util.dart';
 import 'package:webthree/json_rpc.dart';
-import 'package:webthree/src/browser/js_util_stub.dart';
 
 class EthereumUserRejected implements Exception {
   @override

--- a/lib/src/core/exception.dart
+++ b/lib/src/core/exception.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
-import 'dart:js_util';
 
 import 'package:webthree/json_rpc.dart';
+import 'package:webthree/src/browser/js_util_stub.dart';
 
 class EthereumUserRejected implements Exception {
   @override

--- a/lib/src/core/exception.dart
+++ b/lib/src/core/exception.dart
@@ -1,0 +1,83 @@
+import 'dart:convert';
+import 'dart:js_util';
+
+import 'package:webthree/json_rpc.dart';
+
+class EthereumUserRejected implements Exception {
+  @override
+  String toString() => 'EthereumUserRejected: User rejected the request';
+}
+
+class EthereumException implements Exception {
+  final int code;
+  final String message;
+  final dynamic data;
+
+  EthereumException(this.code, this.message, this.data);
+
+  @override
+  String toString() => 'EthereumException: $code $message';
+}
+
+class EthersException implements Exception {
+  final String code;
+  final String reason;
+  final Map<String, dynamic> rawError;
+
+  EthersException(this.code, this.reason, this.rawError);
+
+  @override
+  String toString() => 'EthersException: $code $reason';
+}
+
+class ExceptionUtils {
+  ExceptionUtils();
+
+  /// Analyze Exception to throw a typed exception
+  static void analyzeException(Object e) {
+    // Case of Trust Wallet for example...
+    if (e.runtimeType.toString() == 'NativeError') {
+      if (e.toString().toLowerCase().contains('user rejected the request')) {
+        throw EthereumUserRejected();
+      } else {
+        throw UnimplementedError(e.toString());
+      }
+    } else {
+      // Case of Metamask...
+      final err = json.decode(json.encode(dartify(e))) as Map<String, dynamic>;
+      switch (err['code']) {
+        case 4001:
+          throw EthereumUserRejected();
+        case -32603:
+          String rpcErrorData = err['message'].toString().replaceFirst(
+              "[ethjs-query] while formatting outputs from RPC '{\"value\":",
+              '');
+          if (rpcErrorData.length - 2 > 0) {
+            rpcErrorData = rpcErrorData.substring(0, rpcErrorData.length - 2);
+          }
+          final rpcErrorJson = json.decode(rpcErrorData);
+          throw RPCError(
+            rpcErrorJson['data']['code'] ?? '',
+            rpcErrorJson['data']['message'] ?? '',
+            rpcErrorJson['data']['data'] ?? '',
+          );
+        default:
+          if (err['message'] != null) {
+            throw EthereumException(
+              err['code'],
+              err['message'],
+              err['data'],
+            );
+          } else if (err['reason'] != null) {
+            throw EthersException(
+              err['code'],
+              err['reason'],
+              err,
+            );
+          } else {
+            throw UnimplementedError(e.toString());
+          }
+      }
+    }
+  }
+}

--- a/lib/src/core/exception.dart
+++ b/lib/src/core/exception.dart
@@ -1,7 +1,7 @@
 import 'dart:convert';
 
-import 'package:js/js_util.dart';
 import 'package:webthree/json_rpc.dart';
+import 'package:webthree/src/browser/js_util_stub.dart';
 
 class EthereumUserRejected implements Exception {
   @override

--- a/lib/src/core/exception_utils_io.dart
+++ b/lib/src/core/exception_utils_io.dart
@@ -1,0 +1,14 @@
+import 'package:webthree/src/core/exception.dart';
+
+class ExceptionUtils {
+  ExceptionUtils();
+
+  /// Analyze Exception to throw a typed exception
+  static void analyzeException(Object e) {
+    if (e.toString().toLowerCase().contains('user rejected the request')) {
+      throw EthereumUserRejected();
+    } else {
+      throw UnimplementedError(e.toString());
+    }
+  }
+}

--- a/lib/src/core/exception_utils_js.dart
+++ b/lib/src/core/exception_utils_js.dart
@@ -1,0 +1,57 @@
+import 'dart:convert';
+
+import 'package:js/js_util.dart';
+import 'package:webthree/json_rpc.dart';
+import 'package:webthree/src/core/exception.dart';
+
+class ExceptionUtils {
+  ExceptionUtils();
+
+  /// Analyze Exception to throw a typed exception
+  static void analyzeException(Object e) {
+    // Case of Trust Wallet for example...
+    if (e.runtimeType.toString() == 'NativeError') {
+      if (e.toString().toLowerCase().contains('user rejected the request')) {
+        throw EthereumUserRejected();
+      } else {
+        throw UnimplementedError(e.toString());
+      }
+    } else {
+      // Case of Metamask...
+      final err = json.decode(json.encode(dartify(e))) as Map<String, dynamic>;
+      switch (err['code']) {
+        case 4001:
+          throw EthereumUserRejected();
+        case -32603:
+          String rpcErrorData = err['message'].toString().replaceFirst(
+              "[ethjs-query] while formatting outputs from RPC '{\"value\":",
+              '');
+          if (rpcErrorData.length - 2 > 0) {
+            rpcErrorData = rpcErrorData.substring(0, rpcErrorData.length - 2);
+          }
+          final rpcErrorJson = json.decode(rpcErrorData);
+          throw RPCError(
+            rpcErrorJson['data']['code'] ?? '',
+            rpcErrorJson['data']['message'] ?? '',
+            rpcErrorJson['data']['data'] ?? '',
+          );
+        default:
+          if (err['message'] != null) {
+            throw EthereumException(
+              err['code'],
+              err['message'],
+              err['data'],
+            );
+          } else if (err['reason'] != null) {
+            throw EthersException(
+              err['code'],
+              err['reason'],
+              err,
+            );
+          } else {
+            throw UnimplementedError(e.toString());
+          }
+      }
+    }
+  }
+}

--- a/lib/webthree.dart
+++ b/lib/webthree.dart
@@ -29,6 +29,7 @@ export 'src/core/amount.dart';
 export 'src/core/block_information.dart';
 export 'src/core/block_number.dart';
 export 'src/core/eip1559_information.dart';
+export 'src/core/exception.dart';
 export 'src/core/sync_information.dart';
 
 part 'src/core/client.dart';

--- a/lib/webthree.dart
+++ b/lib/webthree.dart
@@ -26,7 +26,6 @@ export 'contracts.dart';
 export 'credentials.dart';
 export 'src/core/block_information.dart';
 export 'src/core/block_number.dart';
-export 'src/core/eip1559_information.dart';
 export 'src/core/exception.dart';
 export 'src/core/sync_information.dart';
 


### PR DESCRIPTION
This PR contains a new feature to manage error from EVM Wallet
This allows to add specific Exception to manage the behaviour when user rejects the request in the wallet.
The other thing is to manage RPC Error. This useful to manage Revert process in solidity smart contrat and get the `error` 

`EthereumUserRejected` = When user rejects manually in the wallet a transaction
`RPCError` = If error is a RPC Error and contains `code`, `message` and `data` fields
`EthereumException` = If error is not from a RPC Error and contains `code`, `message` and `data` fields
`EthersException` = If error is not from a RPC Error and contains `code`, `reason` fields
`UnimplementedError`= if error is not implemented

In the case of RPCError, client can manage json content
An example:
```
{
  "value": {
    "code": -32603,
    "data": {
      "message": "VM Exception while processing transaction: revert ERC20: transfer amount exceeds balance",
      "code": -32000,
      "data": {
        "0x5c67ee0be489da9e85c5380b63120a10cef370622b282f3f623b80355461327e": {
          "error": "revert",
          "program_counter": 2411,
          "return": "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000002645524332303a207472616e7366657220616d6f756e7420657863656564732062616c616e63650000000000000000000000000000000000000000000000000000",
          "reason": "ERC20: transfer amount exceeds balance"
        },
        "stack": "RuntimeError: VM Exception while processing transaction: revert ERC20: transfer amount exceeds balance\n    at Function.RuntimeError.fromResults (/Applications/Ganache.app/Contents/Resources/static/node/node_modules/ganache-core/lib/utils/runtimeerror.js:94:13)\n    at BlockchainDouble.processBlock (/Applications/Ganache.app/Contents/Resources/static/node/node_modules/ganache-core/lib/blockchain_double.js:627:24)\n    at runMicrotasks (<anonymous>)\n    at processTicksAndRejections (internal/process/task_queues.js:93:5)",
        "name": "RuntimeError"
      }
    }
  }
}
```

The `reason` field contains the revert message.
 
