### PR TITLE
Add helper for handling amounts with decimals in `EtherAmount` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.5.11
+- Add helper for handling amounts with decimals in `EtherAmount` class
+
 ## 2.5.10
 - Report of Web3Dart's last commits
 - DeployedContract function method supports more than one function with different parameters

--- a/lib/src/core/ether_amount.dart
+++ b/lib/src/core/ether_amount.dart
@@ -49,6 +49,13 @@ class EtherAmount {
     return EtherAmount.inWei(wei);
   }
 
+  /// Constructs an amount of Ether by a unit and its amount.
+  factory EtherAmount.fromDouble(EtherUnit unit, double amount) {
+    final wei = Decimal.parse(_factors[unit]!.toString()) *
+        Decimal.parse(amount.toString());
+    return EtherAmount.inWei(wei.toBigInt());
+  }
+
   /// Gets the value of this amount in the specified unit as a whole number.
   /// **WARNING**: For all units except for [EtherUnit.wei], this method will
   /// discard the remainder occurring in the division, making it unsuitable for

--- a/lib/src/utils/decimal.dart
+++ b/lib/src/utils/decimal.dart
@@ -1,0 +1,389 @@
+// Copyright 2013 Alexandre Ardhuin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:webthree/src/utils/rational.dart';
+
+final _i0 = BigInt.zero;
+final _i1 = BigInt.one;
+final _i2 = BigInt.two;
+final _i5 = BigInt.from(5);
+final _r10 = Rational.fromInt(10);
+
+/// A number that can be exactly written with a finite number of digits in the
+/// decimal system.
+class Decimal implements Comparable<Decimal> {
+  /// Create a new decimal from its rational value.
+  Decimal._(this._rational) : assert(_rational.hasFinitePrecision);
+
+  /// Create a new [Decimal] from a [BigInt].
+  factory Decimal.fromBigInt(BigInt value) => value.toRational().toDecimal();
+
+  /// Create a new [Decimal] from an [int].
+  factory Decimal.fromInt(int value) => Decimal.fromBigInt(BigInt.from(value));
+
+  /// Create a new [Decimal] from its [String] representation.
+  factory Decimal.fromJson(String value) => Decimal.parse(value);
+
+  final Rational _rational;
+
+  /// Parses [source] as a decimal literal and returns its value as [Decimal].
+  static Decimal parse(String source) => Rational.parse(source).toDecimal();
+
+  /// Parses [source] as a decimal literal and returns its value as [Decimal].
+  static Decimal? tryParse(String source) {
+    try {
+      return Decimal.parse(source);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// The [Decimal] corresponding to `0`.
+  static Decimal zero = Decimal.fromInt(0);
+
+  /// The [Decimal] corresponding to `1`.
+  static Decimal one = Decimal.fromInt(1);
+
+  /// The [Decimal] corresponding to `10`.
+  static Decimal ten = Decimal.fromInt(10);
+
+  /// The [Rational] corresponding to `this`.
+  Rational toRational() => _rational;
+
+  /// Returns `true` if `this` is an integer.
+  bool get isInteger => _rational.isInteger;
+
+  /// Returns a [Rational] corresponding to `1/this`.
+  Rational get inverse => _rational.inverse;
+
+  @override
+  bool operator ==(Object other) =>
+      other is Decimal && _rational == other._rational;
+
+  @override
+  int get hashCode => _rational.hashCode;
+
+  /// Returns a [String] representation of `this`.
+  @override
+  String toString() {
+    if (_rational.isInteger) return _rational.toString();
+    var value = toStringAsFixed(scale);
+    while (
+        value.contains('.') && (value.endsWith('0') || value.endsWith('.'))) {
+      value = value.substring(0, value.length - 1);
+    }
+    return value;
+  }
+
+  /// Converts `this` to [String] by using [toString].
+  String toJson() => toString();
+
+  @override
+  int compareTo(Decimal other) => _rational.compareTo(other._rational);
+
+  /// Addition operator.
+  Decimal operator +(Decimal other) =>
+      (_rational + other._rational).toDecimal();
+
+  /// Subtraction operator.
+  Decimal operator -(Decimal other) =>
+      (_rational - other._rational).toDecimal();
+
+  /// Multiplication operator.
+  Decimal operator *(Decimal other) =>
+      (_rational * other._rational).toDecimal();
+
+  /// Euclidean modulo operator.
+  ///
+  /// See [num.operator%].
+  Decimal operator %(Decimal other) =>
+      (_rational % other._rational).toDecimal();
+
+  /// Division operator.
+  Rational operator /(Decimal other) => _rational / other._rational;
+
+  /// Truncating division operator.
+  ///
+  /// See [num.operator~/].
+  BigInt operator ~/(Decimal other) => _rational ~/ other._rational;
+
+  /// Returns the negative value of this rational.
+  Decimal operator -() => (-_rational).toDecimal();
+
+  /// Return the remainder from dividing this [Decimal] by [other].
+  Decimal remainder(Decimal other) =>
+      (_rational.remainder(other._rational)).toDecimal();
+
+  /// Whether this number is numerically smaller than [other].
+  bool operator <(Decimal other) => _rational < other._rational;
+
+  /// Whether this number is numerically smaller than or equal to [other].
+  bool operator <=(Decimal other) => _rational <= other._rational;
+
+  /// Whether this number is numerically greater than [other].
+  bool operator >(Decimal other) => _rational > other._rational;
+
+  /// Whether this number is numerically greater than or equal to [other].
+  bool operator >=(Decimal other) => _rational >= other._rational;
+
+  /// Returns the absolute value of `this`.
+  Decimal abs() => _rational.abs().toDecimal();
+
+  /// The signum function value of `this`.
+  ///
+  /// E.e. -1, 0 or 1 as the value of this [Decimal] is negative, zero or positive.
+  int get signum => _rational.signum;
+
+  /// Returns the greatest [Decimal] value no greater than this [Rational].
+  ///
+  /// An optional [scale] value can be provided as parameter to indicate the
+  /// digit used as reference for the operation.
+  ///
+  /// ```
+  /// var x = Decimal.parse('123.4567');
+  /// x.floor(); // 123
+  /// x.floor(scale: 1); // 123.4
+  /// x.floor(scale: 2); // 123.45
+  /// x.floor(scale: -1); // 120
+  /// ```
+  Decimal floor({int scale = 0}) => _scaleAndApply(scale, (e) => e.floor());
+
+  /// Returns the least [Decimal] value that is no smaller than this [Rational].
+  ///
+  /// An optional [scale] value can be provided as parameter to indicate the
+  /// digit used as reference for the operation.
+  ///
+  /// ```
+  /// var x = Decimal.parse('123.4567');
+  /// x.ceil(); // 124
+  /// x.ceil(scale: 1); // 123.5
+  /// x.ceil(scale: 2); // 123.46
+  /// x.ceil(scale: -1); // 130
+  /// ```
+  Decimal ceil({int scale = 0}) => _scaleAndApply(scale, (e) => e.ceil());
+
+  /// Returns the [Decimal] value closest to this number.
+  ///
+  /// Rounds away from zero when there is no closest integer:
+  /// `(3.5).round() == 4` and `(-3.5).round() == -4`.
+  ///
+  /// An optional [scale] value can be provided as parameter to indicate the
+  /// digit used as reference for the operation.
+  ///
+  /// ```
+  /// var x = Decimal.parse('123.4567');
+  /// x.round(); // 123
+  /// x.round(scale: 1); // 123.5
+  /// x.round(scale: 2); // 123.46
+  /// x.round(scale: -1); // 120
+  /// ```
+  Decimal round({int scale = 0}) => _scaleAndApply(scale, (e) => e.round());
+
+  Decimal _scaleAndApply(int scale, BigInt Function(Rational) f) {
+    final scaleFactor = ten.pow(scale);
+    return (f(_rational * scaleFactor).toRational() / scaleFactor).toDecimal();
+  }
+
+  /// The [BigInt] obtained by discarding any fractional digits from `this`.
+  Decimal truncate({int scale = 0}) =>
+      _scaleAndApply(scale, (e) => e.truncate());
+
+  /// Shift the decimal point on the right for positive [value] or on the left
+  /// for negative one.
+  ///
+  /// ```dart
+  /// var x = Decimal.parse('123.4567');
+  /// x.shift(1); // 1234.567
+  /// x.shift(-1); // 12.34567
+  /// ```
+  Decimal shift(int value) => this * ten.pow(value).toDecimal();
+
+  /// Clamps `this` to be in the range [lowerLimit]-[upperLimit].
+  Decimal clamp(Decimal lowerLimit, Decimal upperLimit) =>
+      _rational.clamp(lowerLimit._rational, upperLimit._rational).toDecimal();
+
+  /// The [BigInt] obtained by discarding any fractional digits from `this`.
+  BigInt toBigInt() => _rational.toBigInt();
+
+  /// Returns `this` as a [double].
+  ///
+  /// If the number is not representable as a [double], an approximation is
+  /// returned. For numerically large integers, the approximation may be
+  /// infinite.
+  double toDouble() => _rational.toDouble();
+
+  /// The precision of this [Decimal].
+  ///
+  /// The precision is the number of digits in the unscaled value.
+  ///
+  /// ```dart
+  /// Decimal.parse('0').precision; // => 1
+  /// Decimal.parse('1').precision; // => 1
+  /// Decimal.parse('1.5').precision; // => 2
+  /// Decimal.parse('0.5').precision; // => 2
+  /// ```
+  int get precision {
+    final value = abs();
+    return value.scale + value.toBigInt().toString().length;
+  }
+
+  /// The scale of this [Decimal].
+  ///
+  /// The scale is the number of digits after the decimal point.
+  ///
+  /// ```dart
+  /// Decimal.parse('1.5').scale; // => 1
+  /// Decimal.parse('1').scale; // => 0
+  /// ```
+  int get scale {
+    var i = 0;
+    var x = _rational;
+    while (!x.isInteger) {
+      i++;
+      x *= _r10;
+    }
+    return i;
+  }
+
+  /// A decimal-point string-representation of this number with [fractionDigits]
+  /// digits after the decimal point.
+  String toStringAsFixed(int fractionDigits) {
+    assert(fractionDigits >= 0);
+    if (fractionDigits == 0) return round().toBigInt().toString();
+    final value = round(scale: fractionDigits);
+    final intPart = value.toBigInt().abs();
+    final decimalPart =
+        (one + value.abs() - intPart.toDecimal()).shift(fractionDigits);
+    return '${value < zero ? '-' : ''}$intPart.${decimalPart.toString().substring(1)}';
+  }
+
+  /// An exponential string-representation of this number with [fractionDigits]
+  /// digits after the decimal point.
+  String toStringAsExponential([int fractionDigits = 0]) {
+    assert(fractionDigits >= 0);
+
+    final negative = this < zero;
+    var value = abs();
+    var eValue = 0;
+    while (value < one && value > zero) {
+      value *= ten;
+      eValue--;
+    }
+    while (value >= ten) {
+      value = (value / ten).toDecimal();
+      eValue++;
+    }
+    value = value.round(scale: fractionDigits);
+    // If the rounded value is 10, then divide it once more to make it follow
+    // the normalized scientific notation. See https://github.com/a14n/dart-decimal/issues/74
+    if (value == ten) {
+      value = (value / ten).toDecimal();
+      eValue++;
+    }
+
+    return <String>[
+      if (negative) '-',
+      value.toStringAsFixed(fractionDigits),
+      'e',
+      if (eValue >= 0) '+',
+      '$eValue',
+    ].join();
+  }
+
+  /// A string representation with [precision] significant digits.
+  String toStringAsPrecision(int precision) {
+    assert(precision > 0);
+
+    if (this == zero) {
+      return <String>[
+        '0',
+        if (precision > 1) '.',
+        for (var i = 1; i < precision; i++) '0',
+      ].join();
+    }
+
+    final limit = ten.pow(precision).toDecimal();
+
+    var shift = one;
+    final absValue = abs();
+    var pad = 0;
+    while (absValue * shift < limit) {
+      pad++;
+      shift *= ten;
+    }
+    while (absValue * shift >= limit) {
+      pad--;
+      shift = (shift / ten).toDecimal();
+    }
+    final value = ((this * shift).round() / shift).toDecimal();
+    return pad <= 0 ? value.toString() : value.toStringAsFixed(pad);
+  }
+
+  /// Returns `this` to the power of [exponent].
+  ///
+  /// Returns [Rational.one] if the [exponent] equals `0`.
+  Rational pow(int exponent) => _rational.pow(exponent);
+}
+
+/// Extensions on [Rational].
+extension RationalExt on Rational {
+  /// Returns a [Decimal] corresponding to `this`.
+  ///
+  /// Some rational like `1/3` can not be converted to decimal because they need
+  /// an infinite number of digits. For those cases (where [hasFinitePrecision]
+  /// is `false`) a [scaleOnInfinitePrecision] and a [toBigInt] can be provided
+  /// to convert `this` to a [Decimal] representation. By default [toBigInt]
+  /// use [Rational.truncate] to limit the number of digit.
+  ///
+  /// Note that the returned decimal will not be exactly equal to `this`.
+  Decimal toDecimal({
+    int? scaleOnInfinitePrecision,
+    BigInt Function(Rational)? toBigInt,
+  }) {
+    if (scaleOnInfinitePrecision == null || hasFinitePrecision) {
+      return Decimal._(this);
+    }
+    final scaleFactor = _r10.pow(scaleOnInfinitePrecision);
+    toBigInt ??= (value) => value.truncate();
+    return Decimal._(toBigInt(this * scaleFactor).toRational() / scaleFactor);
+  }
+
+  /// Returns `true` if this [Rational] has a finite precision.
+  ///
+  /// Having a finite precision means that the number can be exactly represented
+  /// as decimal with a finite number of fractional digits.
+  bool get hasFinitePrecision {
+    // the denominator should only be a product of powers of 2 and 5
+    var den = denominator;
+    while (den % _i5 == _i0) {
+      den = den ~/ _i5;
+    }
+    while (den % _i2 == _i0) {
+      den = den ~/ _i2;
+    }
+    return den == _i1;
+  }
+}
+
+/// Extensions on [BigInt].
+extension BigIntExt on BigInt {
+  /// This [BigInt] as a [Decimal].
+  Decimal toDecimal() => Decimal.fromBigInt(this);
+}
+
+/// Extensions on [int].
+extension IntExt on int {
+  /// This [int] as a [Decimal].
+  Decimal toDecimal() => Decimal.fromInt(this);
+}

--- a/lib/src/utils/rational.dart
+++ b/lib/src/utils/rational.dart
@@ -1,0 +1,306 @@
+// Copyright 2013 Alexandre Ardhuin
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+final _pattern = RegExp(r'^([+-]?\d*)(\.\d*)?([eE][+-]?\d+)?$');
+
+final _r0 = Rational.zero;
+final _r5 = Rational.fromInt(5);
+final _r10 = Rational.fromInt(10);
+
+final _i0 = BigInt.zero;
+final _i1 = BigInt.one;
+final _i10 = BigInt.from(10);
+
+BigInt _gcd(BigInt a, BigInt b) {
+  while (b != _i0) {
+    final t = b;
+    b = a % b;
+    a = t;
+  }
+  return a;
+}
+
+/// A number that can be expressed as a fraction of two integers, a [numerator]
+/// and a non-zero [denominator].
+///
+/// This fraction is stored in its canonical form. The canonical form is the
+/// rational number expressed in a unique way as an irreducible fraction a/b,
+/// where a and b are coprime integers and b > 0.
+///
+/// `Rational(2, 4)` corresponding to `2/4` will be created with its canonical
+/// form `1/2`. That means `Rational(2, 4).numerator` will be equal to `1` and
+/// `Rational(2, 4).denominator` equal to `2`.
+class Rational implements Comparable<Rational> {
+  /// Create a new rational number from its [numerator] and a non-zero
+  /// [denominator].
+  ///
+  /// If the [denominator] is omitted then its value will be `1`.
+  Rational._fromCanonicalForm(this.numerator, this.denominator)
+      : assert(denominator > _i0),
+        assert(numerator.abs().gcd(denominator) == _i1);
+
+  /// Create a new rational number from its [numerator] and a non-zero
+  /// [denominator].
+  ///
+  /// If the [denominator] is omitted then its value will be `1`.
+  factory Rational(BigInt numerator, [BigInt? denominator]) {
+    if (denominator == null) return Rational._fromCanonicalForm(numerator, _i1);
+    if (denominator == _i0) {
+      throw ArgumentError('zero can not be used as denominator');
+    }
+    if (numerator == _i0) return Rational._fromCanonicalForm(_i0, _i1);
+    if (denominator < _i0) {
+      numerator = -numerator;
+      denominator = -denominator;
+    }
+    // TODO(a14n): switch back when https://github.com/dart-lang/sdk/issues/46180 is fixed
+    // final gcd = numerator.abs().gcd(denominator.abs());
+    final gcd = _gcd(numerator.abs(), denominator.abs());
+    return Rational._fromCanonicalForm(numerator ~/ gcd, denominator ~/ gcd);
+  }
+
+  /// Create a new rational number from its [numerator] and a non-zero
+  /// [denominator].
+  ///
+  /// If the [denominator] is omitted then its value will be `1`.
+  factory Rational.fromInt(int numerator, [int denominator = 1]) =>
+      Rational(BigInt.from(numerator), BigInt.from(denominator));
+
+  /// The numerator of this rational number.
+  final BigInt numerator;
+
+  /// The denominator of this rational number.
+  final BigInt denominator;
+
+  /// Parses [source] as a decimal literal and returns its value as [Rational].
+  static Rational parse(String source) {
+    final match = _pattern.firstMatch(source);
+    if (match == null) {
+      throw FormatException('$source is not a valid format');
+    }
+    final group1 = match.group(1);
+    final group2 = match.group(2);
+    final group3 = match.group(3);
+
+    var numerator = _i0;
+    var denominator = _i1;
+    if (group2 != null) {
+      for (var i = 1; i < group2.length; i++) {
+        denominator = denominator * _i10;
+      }
+      numerator = BigInt.parse('$group1${group2.substring(1)}');
+    } else {
+      numerator = BigInt.parse(group1!);
+    }
+    if (group3 != null) {
+      var exponent = int.parse(group3.substring(1));
+      if (exponent > 0) {
+        numerator *= _i10.pow(exponent);
+      }
+      if (exponent < 0) {
+        denominator *= _i10.pow(exponent.abs());
+      }
+    }
+    return Rational(numerator, denominator);
+  }
+
+  /// Parses [source] as a decimal literal and returns its value as [Rational].
+  ///
+  /// As [parse] except that this method returns `null` if the input is not
+  /// valid
+  static Rational? tryParse(String source) {
+    try {
+      return parse(source);
+    } on FormatException {
+      return null;
+    }
+  }
+
+  /// The rational number corresponding to `0`.
+  static final zero = Rational.fromInt(0);
+
+  /// The rational number corresponding to `1`.
+  static final one = Rational.fromInt(1);
+
+  /// Returns `true` if `this` is an integer.
+  bool get isInteger => denominator == _i1;
+
+  /// Returns the [Rational] [denominator]/[numerator].
+  Rational get inverse => Rational(denominator, numerator);
+
+  @override
+  int get hashCode => Object.hash(numerator, denominator);
+
+  @override
+  bool operator ==(Object other) =>
+      other is Rational &&
+      numerator == other.numerator &&
+      denominator == other.denominator;
+
+  @override
+  String toString() {
+    if (numerator == _i0) return '0';
+    if (isInteger) {
+      return '$numerator';
+    } else {
+      return '$numerator/$denominator';
+    }
+  }
+
+  @override
+  int compareTo(Rational other) =>
+      (numerator * other.denominator).compareTo(other.numerator * denominator);
+
+  /// Addition operator.
+  Rational operator +(Rational other) => Rational(
+        numerator * other.denominator + other.numerator * denominator,
+        denominator * other.denominator,
+      );
+
+  /// Subtraction operator.
+  Rational operator -(Rational other) => Rational(
+        numerator * other.denominator - other.numerator * denominator,
+        denominator * other.denominator,
+      );
+
+  /// Multiplication operator.
+  Rational operator *(Rational other) => Rational(
+        numerator * other.numerator,
+        denominator * other.denominator,
+      );
+
+  /// Euclidean modulo operator.
+  ///
+  /// See [num.operator%].
+  Rational operator %(Rational other) {
+    final remainder = this.remainder(other);
+    if (remainder == _r0) return _r0;
+    return remainder + (_isNegative ? other.abs() : _r0);
+  }
+
+  /// Division operator.
+  Rational operator /(Rational other) => Rational(
+        numerator * other.denominator,
+        denominator * other.numerator,
+      );
+
+  /// Truncating division operator.
+  ///
+  /// See [num.operator~/].
+  BigInt operator ~/(Rational other) => (this / other).truncate();
+
+  /// Returns the negative value of this rational.
+  Rational operator -() => Rational(-numerator, denominator);
+
+  /// Returns the remainder from dividing this [Rational] by [other].
+  Rational remainder(Rational other) =>
+      this - (this ~/ other).toRational() * other;
+
+  /// Whether this number is numerically smaller than [other].
+  bool operator <(Rational other) => compareTo(other) < 0;
+
+  /// Whether this number is numerically smaller than or equal to [other].
+  bool operator <=(Rational other) => compareTo(other) <= 0;
+
+  /// Whether this number is numerically greater than [other].
+  bool operator >(Rational other) => compareTo(other) > 0;
+
+  /// Whether this number is numerically greater than or equal to [other].
+  bool operator >=(Rational other) => compareTo(other) >= 0;
+
+  bool get _isNegative => numerator < _i0;
+
+  /// Returns the absolute value of `this`.
+  Rational abs() => _isNegative ? (-this) : this;
+
+  /// The signum function value of `this`.
+  ///
+  /// E.e. -1, 0 or 1 as the value of this [Rational] is negative, zero or positive.
+  int get signum {
+    final v = compareTo(_r0);
+    if (v < 0) return -1;
+    if (v > 0) return 1;
+    return 0;
+  }
+
+  /// Returns the [BigInt] value closest to this number.
+  ///
+  /// Rounds away from zero when there is no closest integer:
+  /// `(3.5).round() == 4` and `(-3.5).round() == -4`.
+  BigInt round() {
+    final abs = this.abs();
+    final absBy10 = abs * _r10;
+    var r = abs.truncate();
+    if (absBy10 % _r10 >= _r5) r += _i1;
+    return _isNegative ? -r : r;
+  }
+
+  /// Returns the greatest [BigInt] value no greater than this [Rational].
+  BigInt floor() => isInteger
+      ? truncate()
+      : _isNegative
+          ? (truncate() - _i1)
+          : truncate();
+
+  /// Returns the least [BigInt] value that is no smaller than this [Rational].
+  BigInt ceil() => isInteger
+      ? truncate()
+      : _isNegative
+          ? truncate()
+          : (truncate() + _i1);
+
+  /// The [BigInt] obtained by discarding any fractional digits from `this`.
+  BigInt truncate() => numerator ~/ denominator;
+
+  /// Clamps `this` to be in the range [lowerLimit]-[upperLimit].
+  Rational clamp(Rational lowerLimit, Rational upperLimit) => this < lowerLimit
+      ? lowerLimit
+      : this > upperLimit
+          ? upperLimit
+          : this;
+
+  /// The [BigInt] obtained by discarding any fractional digits from `this`.
+  ///
+  /// Equivalent to [truncate].
+  BigInt toBigInt() => truncate();
+
+  /// Returns `this` as a [double].
+  ///
+  /// If the number is not representable as a [double], an approximation is
+  /// returned. For numerically large integers, the approximation may be
+  /// infinite.
+  double toDouble() => numerator / denominator;
+
+  /// Returns `this` to the power of [exponent].
+  ///
+  /// Returns [one] if the [exponent] equals `0`.
+  Rational pow(int exponent) => exponent.isNegative
+      ? inverse.pow(-exponent)
+      : Rational(
+          numerator.pow(exponent),
+          denominator.pow(exponent),
+        );
+}
+
+/// Extensions on [BigInt].
+extension BigIntExt on BigInt {
+  /// This [BigInt] as a [Rational].
+  Rational toRational() => Rational(this);
+}
+
+/// Extensions on [int].
+extension IntExt on int {
+  /// This [int] as a [Rational].
+  Rational toRational() => Rational.fromInt(this);
+}

--- a/lib/webthree.dart
+++ b/lib/webthree.dart
@@ -4,12 +4,12 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
-import 'package:decimal/decimal.dart';
 import 'package:http/http.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:meta/meta.dart';
 import 'package:stream_channel/stream_channel.dart';
 import 'package:stream_transform/stream_transform.dart';
+import 'package:webthree/src/utils/decimal.dart';
 import 'package:webthree/src/utils/length_tracking_byte_sink.dart';
 
 import 'contracts.dart';

--- a/lib/webthree.dart
+++ b/lib/webthree.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:collection/collection.dart';
+import 'package:decimal/decimal.dart';
 import 'package:http/http.dart';
 import 'package:json_rpc_2/json_rpc_2.dart' as rpc;
 import 'package:meta/meta.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   collection: ^1.16.0
   convert: ^3.1.1
   dart_style: ^2.3.2
+  decimal: ^2.3.3
   http: ^1.0.0
   js: ^0.6.7
   json_rpc_2: ^3.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   collection: ^1.16.0
   convert: ^3.1.1
   dart_style: ^2.3.2
-  decimal: ^2.3.3
   http: ^1.0.0
   js: ^0.6.7
   json_rpc_2: ^3.0.2


### PR DESCRIPTION
This PR allows to help developer to manipulate amount in `double`.

To avoid some issues related to floating-point precision in Dart, i added a new method in `EtherAmount` class .

Example:
To send 100000.001 Ether to a contract, you can do : 
```
final amount = 100000.001;
final ethAmount = EtherAmount.fromDouble(EtherUnit.ether, amount);
```